### PR TITLE
Feat upgrade raft ttl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onsi/ginkgo v1.15.0 // indirect
 	github.com/onsi/gomega v1.10.5 // indirect
 	github.com/pelletier/go-toml v1.8.1 // indirect
-	github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726 // indirect
+	github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726
 	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/tidwall/btree v0.4.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -34,4 +34,4 @@ require (
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 )
 
-replace github.com/ledisdb/ledisdb v0.0.0-20200510135210-d35789ec47e6 => github.com/gitsrc/ledisdb v0.0.0-20210310084430-d59a1134a6c5
+replace github.com/ledisdb/ledisdb v0.0.0-20200510135210-d35789ec47e6 => github.com/gitsrc/ledisdb v0.0.0-20210311085546-2e33308de99f

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/garyburd/redigo v1.6.2 h1:yE/pwKCrbLpLpQICzYTeZ7JsTA/C53wFTJHaEtRqniM=
 github.com/garyburd/redigo v1.6.2/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
-github.com/gitsrc/ledisdb v0.0.0-20210310084430-d59a1134a6c5 h1:BauMdZwaVjjE6pK6NBQIh7JADJj6++1aSpZNh1/vVzA=
-github.com/gitsrc/ledisdb v0.0.0-20210310084430-d59a1134a6c5/go.mod h1:n931TsDuKuq+uX4v1fulaMbA/7ZLLhjc85h7chZGBCQ=
+github.com/gitsrc/ledisdb v0.0.0-20210311085546-2e33308de99f h1:gjl6DyMIYTI+SuMj3eS71CSZxQUcO+xzI8jtxV0GDUw=
+github.com/gitsrc/ledisdb v0.0.0-20210311085546-2e33308de99f/go.mod h1:n931TsDuKuq+uX4v1fulaMbA/7ZLLhjc85h7chZGBCQ=
 github.com/glendc/gopher-json v0.0.0-20170414221815-dc4743023d0c/go.mod h1:Gja1A+xZ9BoviGJNA2E9vFkPjjsl+CoJxSXiQM1UXtw=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/rafthub/redisService.go
+++ b/rafthub/redisService.go
@@ -2,8 +2,8 @@
  * @Author: gitsrc
  * @Date: 2020-12-23 14:26:19
  * @LastEditors: gitsrc
- * @LastEditTime: 2020-12-23 14:51:06
- * @FilePath: /RaftHub/redisService.go
+ * @LastEditTime: 2021-03-11 17:56:27
+ * @FilePath: /IceFireDB/rafthub/redisService.go
  */
 
 package rafthub
@@ -13,7 +13,9 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/garyburd/redigo/redis"
 	"github.com/tidwall/redcon"
@@ -144,6 +146,46 @@ func redisServiceHandler(s Service, ln net.Listener) {
 			for _, cmd := range conn.ReadPipeline() {
 				args = append(args, redisCommandToArgs(cmd))
 			}
+
+			/*
+				这边针对raft分布式，进行指令重写，SETEX => SETEXAT
+			*/
+			for index, cmdArgs := range args {
+				if len(cmdArgs) == 0 {
+					continue
+				}
+
+				switch strings.ToUpper(cmdArgs[0]) {
+				case "SETEX": //重写SETEX指令到 SETEXAT指令
+					if len(cmdArgs) < 4 {
+						continue
+					}
+					ttl, err := strconv.ParseInt(cmdArgs[2], 10, 64)
+					if err != nil {
+						continue
+					}
+					timestamp := time.Now().Unix() + ttl
+					cmdArgs[2] = strconv.FormatInt(timestamp, 10)
+					cmdArgs[0] = "SETEXAT"
+
+				case "EXPIRE": //重写EXPIRE指令到 EXPIREAT指令
+					if len(cmdArgs) < 3 {
+						continue
+					}
+
+					ttl, err := strconv.ParseInt(cmdArgs[2], 10, 64)
+					if err != nil {
+						continue
+					}
+					timestamp := time.Now().Unix() + ttl
+					cmdArgs[2] = strconv.FormatInt(timestamp, 10)
+					cmdArgs[0] = "EXPIREAT"
+
+				}
+
+				//log.Println(args[index])
+			}
+
 			redisServiceExecArgs(s, client, conn, args)
 		},
 		// handle opened connection

--- a/rafthub/redisService.go
+++ b/rafthub/redisService.go
@@ -2,7 +2,7 @@
  * @Author: gitsrc
  * @Date: 2020-12-23 14:26:19
  * @LastEditors: gitsrc
- * @LastEditTime: 2021-03-11 17:56:27
+ * @LastEditTime: 2021-03-11 18:37:16
  * @FilePath: /IceFireDB/rafthub/redisService.go
  */
 
@@ -150,7 +150,7 @@ func redisServiceHandler(s Service, ln net.Listener) {
 			/*
 				这边针对raft分布式，进行指令重写，SETEX => SETEXAT
 			*/
-			for index, cmdArgs := range args {
+			for _, cmdArgs := range args {
 				if len(cmdArgs) == 0 {
 					continue
 				}
@@ -180,6 +180,19 @@ func redisServiceHandler(s Service, ln net.Listener) {
 					timestamp := time.Now().Unix() + ttl
 					cmdArgs[2] = strconv.FormatInt(timestamp, 10)
 					cmdArgs[0] = "EXPIREAT"
+				case "HEXPIRE": //重写HEXPIRE指令到 HEXPIREAT指令
+					if len(cmdArgs) < 3 {
+						continue
+					}
+
+					ttl, err := strconv.ParseInt(cmdArgs[2], 10, 64)
+					if err != nil {
+						continue
+					}
+
+					timestamp := time.Now().Unix() + ttl
+					cmdArgs[2] = strconv.FormatInt(timestamp, 10)
+					cmdArgs[0] = "HEXPIREAT"
 
 				}
 

--- a/strings.go
+++ b/strings.go
@@ -2,7 +2,7 @@
  * @Author: gitsrc
  * @Date: 2021-03-08 17:57:04
  * @LastEditors: gitsrc
- * @LastEditTime: 2021-03-10 17:30:49
+ * @LastEditTime: 2021-03-11 14:32:00
  * @FilePath: /IceFireDB/strings.go
  */
 
@@ -38,6 +38,7 @@ func init() {
 	conf.AddWriteCommand("SET", cmdSET)
 	conf.AddWriteCommand("SETNX", cmdSETNX)
 	conf.AddWriteCommand("SETEX", cmdSETEX)
+	conf.AddWriteCommand("SETEXAT", cmdSETEXAT)
 	conf.AddWriteCommand("SETRANGE", cmdSETRANGE)
 	conf.AddReadCommand("STRLEN", cmdSTRLEN)
 	conf.AddWriteCommand("EXPIRE", cmdEXPIRE)
@@ -68,7 +69,7 @@ func cmdEXPIREAT(m rafthub.Machine, args []string) (interface{}, error) {
 		return nil, err
 	}
 
-	v, err := ldb.ExpireAt([]byte(args[1]), when)
+	v, err := ldb.ExpireAtWithoutCheck([]byte(args[1]), when)
 	if err != nil {
 		return nil, err
 	}
@@ -369,6 +370,22 @@ func cmdSETEX(m rafthub.Machine, args []string) (interface{}, error) {
 	}
 
 	if err := ldb.SetEX([]byte(args[1]), sec, []byte(args[3])); err != nil {
+		return nil, err
+	}
+
+	return redcon.SimpleString("OK"), nil
+}
+
+func cmdSETEXAT(m rafthub.Machine, args []string) (interface{}, error) {
+	if len(args) < 4 {
+		return nil, rafthub.ErrWrongNumArgs
+	}
+	timestamp, err := ledis.StrInt64([]byte(args[2]), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ldb.SetEXAT([]byte(args[1]), timestamp, []byte(args[3])); err != nil {
 		return nil, err
 	}
 

--- a/strings.go
+++ b/strings.go
@@ -2,7 +2,7 @@
  * @Author: gitsrc
  * @Date: 2021-03-08 17:57:04
  * @LastEditors: gitsrc
- * @LastEditTime: 2021-03-11 14:34:44
+ * @LastEditTime: 2021-03-11 17:58:38
  * @FilePath: /IceFireDB/strings.go
  */
 
@@ -10,6 +10,7 @@ package main
 
 import (
 	"strconv"
+	"time"
 
 	"github.com/gitsrc/IceFireDB/rafthub"
 	"github.com/ledisdb/ledisdb/ledis"
@@ -37,27 +38,27 @@ func init() {
 	conf.AddWriteCommand("MSET", cmdMSET)
 	conf.AddWriteCommand("SET", cmdSET)
 	conf.AddWriteCommand("SETNX", cmdSETNX)
-	conf.AddWriteCommand("SETEX", cmdSETEX)
+	//conf.AddWriteCommand("SETEX", cmdSETEX) // SETEX => SETEXAT
 	conf.AddWriteCommand("SETEXAT", cmdSETEXAT)
 	conf.AddWriteCommand("SETRANGE", cmdSETRANGE)
 	conf.AddReadCommand("STRLEN", cmdSTRLEN)
-	conf.AddWriteCommand("EXPIRE", cmdEXPIRE)     //超时指令
+	//conf.AddWriteCommand("EXPIRE", cmdEXPIRE)     //EXPIRE => EXPIREAT
 	conf.AddWriteCommand("EXPIREAT", cmdEXPIREAT) //超时指令
 	conf.AddReadCommand("TTL", cmdTTL)
-	conf.AddWriteCommand("PERSIST", cmdPERSIST)
+	//conf.AddWriteCommand("PERSIST", cmdPERSIST) //禁止:时间持久化
 }
 
-func cmdPERSIST(m rafthub.Machine, args []string) (interface{}, error) {
-	if len(args) != 2 {
-		return nil, rafthub.ErrWrongNumArgs
-	}
+// func cmdPERSIST(m rafthub.Machine, args []string) (interface{}, error) {
+// 	if len(args) != 2 {
+// 		return nil, rafthub.ErrWrongNumArgs
+// 	}
 
-	n, err := ldb.Persist([]byte(args[1]))
-	if err != nil {
-		return nil, err
-	}
-	return redcon.SimpleInt(n), nil
-}
+// 	n, err := ldb.Persist([]byte(args[1]))
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	return redcon.SimpleInt(n), nil
+// }
 
 func cmdEXPIREAT(m rafthub.Machine, args []string) (interface{}, error) {
 	if len(args) != 3 {
@@ -69,7 +70,18 @@ func cmdEXPIREAT(m rafthub.Machine, args []string) (interface{}, error) {
 		return nil, err
 	}
 
-	v, err := ldb.ExpireAtWithoutCheck([]byte(args[1]), when)
+	//如果时间戳小于当前时间，则进行删除操作
+	if when < time.Now().Unix() {
+		keys := make([][]byte, 1)
+		keys[0] = []byte(args[1])
+		_, err := ldb.Del(keys...)
+		if err != nil {
+			return nil, err
+		}
+		return redcon.SimpleInt(1), nil
+	}
+
+	v, err := ldb.ExpireAt([]byte(args[1]), when)
 	if err != nil {
 		return nil, err
 	}
@@ -77,22 +89,22 @@ func cmdEXPIREAT(m rafthub.Machine, args []string) (interface{}, error) {
 	return redcon.SimpleInt(v), nil
 }
 
-func cmdEXPIRE(m rafthub.Machine, args []string) (interface{}, error) {
-	if len(args) != 3 {
-		return nil, rafthub.ErrWrongNumArgs
-	}
+// func cmdEXPIRE(m rafthub.Machine, args []string) (interface{}, error) {
+// 	if len(args) != 3 {
+// 		return nil, rafthub.ErrWrongNumArgs
+// 	}
 
-	duration, err := ledis.StrInt64([]byte(args[2]), nil)
-	if err != nil {
-		return nil, err
-	}
+// 	duration, err := ledis.StrInt64([]byte(args[2]), nil)
+// 	if err != nil {
+// 		return nil, err
+// 	}
 
-	v, err := ldb.Expire([]byte(args[1]), duration)
-	if err != nil {
-		return nil, err
-	}
-	return redcon.SimpleInt(v), nil
-}
+// 	v, err := ldb.Expire([]byte(args[1]), duration)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	return redcon.SimpleInt(v), nil
+// }
 
 func cmdSTRLEN(m rafthub.Machine, args []string) (interface{}, error) {
 	if len(args) != 2 {
@@ -360,21 +372,21 @@ func cmdSET(m rafthub.Machine, args []string) (interface{}, error) {
 	return redcon.SimpleString("OK"), nil
 }
 
-func cmdSETEX(m rafthub.Machine, args []string) (interface{}, error) {
-	if len(args) < 4 {
-		return nil, rafthub.ErrWrongNumArgs
-	}
-	sec, err := ledis.StrInt64([]byte(args[2]), nil)
-	if err != nil {
-		return nil, err
-	}
+// func cmdSETEX(m rafthub.Machine, args []string) (interface{}, error) {
+// 	if len(args) < 4 {
+// 		return nil, rafthub.ErrWrongNumArgs
+// 	}
+// 	sec, err := ledis.StrInt64([]byte(args[2]), nil)
+// 	if err != nil {
+// 		return nil, err
+// 	}
 
-	if err := ldb.SetEX([]byte(args[1]), sec, []byte(args[3])); err != nil {
-		return nil, err
-	}
+// 	if err := ldb.SetEX([]byte(args[1]), sec, []byte(args[3])); err != nil {
+// 		return nil, err
+// 	}
 
-	return redcon.SimpleString("OK"), nil
-}
+// 	return redcon.SimpleString("OK"), nil
+// }
 
 func cmdSETEXAT(m rafthub.Machine, args []string) (interface{}, error) {
 	if len(args) < 4 {
@@ -383,6 +395,17 @@ func cmdSETEXAT(m rafthub.Machine, args []string) (interface{}, error) {
 	timestamp, err := ledis.StrInt64([]byte(args[2]), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	//如果时间戳小于当前时间，则进行删除操作
+	if timestamp < time.Now().Unix() {
+		keys := make([][]byte, 1)
+		keys[0] = []byte(args[1])
+		_, err := ldb.Del(keys...)
+		if err != nil {
+			return nil, err
+		}
+		return redcon.SimpleString("OK"), nil
 	}
 
 	if err := ldb.SetEXAT([]byte(args[1]), timestamp, []byte(args[3])); err != nil {


### PR DESCRIPTION
The current version mainly responds to raft rollback logs, causing the problem of replaying the key expiration time from zero.

Because raft belongs to the log structure, when the program is down, the time expires, and dirty data with this boundary condition will appear.